### PR TITLE
キーワード検索APIに検索ヒット件数を追加

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -12,6 +12,7 @@ module Api
         check_params
         song_search_object = Search::Song.new(@keyword, @num, @page)
         @songs = song_search_object.matches
+        @hit = song_search_object.hit_num
         render 'index', formats: 'json', handlers: 'jbuilder'
       end
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -12,7 +12,7 @@ module Api
         check_params
         song_search_object = Search::Song.new(@keyword, @num, @page)
         @songs = song_search_object.matches
-        @hit = song_search_object.hit_num
+        @hit = song_search_object.hit_count
         render 'index', formats: 'json', handlers: 'jbuilder'
       end
 

--- a/app/models/search/song.rb
+++ b/app/models/search/song.rb
@@ -7,11 +7,16 @@ module Search
       @keyword = keyword
       @num = num
       @page = page
+      @songs = ::Song.where(contains(:title, keyword))
     end
 
     def matches
       offset_num = num * (page - 1)
-      ::Song.where(contains(:title, keyword)).offset(offset_num).limit(num)
+      @songs.offset(offset_num).limit(num)
+    end
+
+    def hit_num
+      @songs.count
     end
   end
 end

--- a/app/models/search/song.rb
+++ b/app/models/search/song.rb
@@ -10,7 +10,7 @@ module Search
     end
 
     def matches
-      offset_num = num * (page - 1)
+      offset_num = @num * (@page - 1)
       @songs.offset(offset_num).limit(num)
     end
 

--- a/app/models/search/song.rb
+++ b/app/models/search/song.rb
@@ -4,7 +4,6 @@ module Search
     attr_accessor :keyword, :num, :page
 
     def initialize(keyword, num, page)
-      @keyword = keyword
       @num = num
       @page = page
       @songs = ::Song.where(contains(:title, keyword))

--- a/app/models/search/song.rb
+++ b/app/models/search/song.rb
@@ -15,7 +15,7 @@ module Search
       @songs.offset(offset_num).limit(num)
     end
 
-    def hit_num
+    def hit_count
       @songs.count
     end
   end

--- a/app/models/search/song.rb
+++ b/app/models/search/song.rb
@@ -15,7 +15,7 @@ module Search
     end
 
     def hit_count
-      @songs.count
+      @songs.length
     end
   end
 end

--- a/app/views/api/v1/search/index.json.jbuilder
+++ b/app/views/api/v1/search/index.json.jbuilder
@@ -1,4 +1,5 @@
 json.set! :keyword, @keyword
+json.set! :hit, @hit
 json.set! :num, @num
 json.set! :page, @page
 json.result @songs, :song_id


### PR DESCRIPTION
close #32

SQLが2度実行されて無駄感があるんだけどどうなんだろう？

以下ログ
```
Processing by Api::V1::SearchController#index as HTML
  Parameters: {"keyword"=>"タイトル"}
   (0.3ms)  SELECT COUNT(*) FROM `songs` WHERE (title LIKE '%タイトル%')
  Rendering api/v1/search/index.json.jbuilder
  Song Load (0.3ms)  SELECT  `songs`.* FROM `songs` WHERE (title LIKE '%タイトル%') LIMIT 10 OFFSET 0
  Rendered api/v1/search/index.json.jbuilder (15.6ms)
Completed 200 OK in 41ms (Views: 21.8ms | ActiveRecord: 1.4ms)
```